### PR TITLE
product id and six digit serial

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,9 @@ def item_serializer(product_id: int, batch_size: int, batch_index: int, batch_id
     
     raw_info = struct.pack("BBBB", product_id, batch_size, batch_index, batch_id)
 
-    return safe32_encode(raw_info)
+    truncated_serial = safe32_encode(raw_info)[1:]
+
+    return truncated_serial
 
 def item_deserializer(serial: str) -> tuple[int, int, int, int]:
     """get information for item from serial
@@ -50,7 +52,7 @@ def item_deserializer(serial: str) -> tuple[int, int, int, int]:
     if len(serial) != 6:
         raise Exception("serial of wrong length, must be 6 characters")
     else:
-        serial = b'0' + bytes(serial, 'utf-8')
+        serial = b'0' + serial.encode()
     
     raw_info = safe32_decode(serial)
     product_id, batch_size, batch_index, batch_id = struct.unpack("BBBB", raw_info)
@@ -84,7 +86,7 @@ if __name__ == "__main__":
             print(f"  {'batch id:':<15}{batch_id:>4}")
     elif product_id is not None and batch_size is not None and batch_id is not None:
             if batch_index is not None:
-                print(f"item serial:  {item_serializer(product_id, batch_size, batch_index, batch_id).decode()[1:]}")
+                print(f"item serial:  {item_serializer(product_id, batch_size, batch_index, batch_id).decode()}")
             else:
                 for i in range(1, batch_size + 1):
-                    print(f"item {i:<3} serial:  {item_serializer(product_id, batch_size, i, batch_id).decode()[1:]}")
+                    print(f"item {i:<3} serial:  {item_serializer(product_id, batch_size, i, batch_id).decode()}")

--- a/main.py
+++ b/main.py
@@ -3,15 +3,17 @@ from safe32 import safe32_encode, safe32_decode
 import struct
 import argparse
 
-def item_serializer(batch_size: int, batch_index: int, batch_id: int) -> bytes:
+def item_serializer(product_id: int, batch_size: int, batch_index: int, batch_id: int) -> bytes:
     """generate safe32 encoded serial number for item
 
     Args:
+        product_id (int): type of item in batch
         batch_size (int): number items in batch
         batch_index (int): which item from batch
         batch_id (int): which batch (sequential)
 
     Raises:
+        Exception: product id too large
         Exception: batch size too large
         Exception: batch id too large
         Exception: batch index larger than batch size
@@ -19,18 +21,20 @@ def item_serializer(batch_size: int, batch_index: int, batch_id: int) -> bytes:
     Returns:
         bytes: serial as bytes
     """
-    if batch_size > 255:
+    if product_id > 255:
+        raise Exception("product id too large, must be less than or equal 255")
+    elif batch_size > 255:
         raise Exception("batch size too large, must be less than or equal 255")
     elif batch_id > 255:
         raise Exception("batch id too large, must be less than or equal 255")
     elif batch_index > batch_size:
         raise Exception("batch index larger than batch index")
     
-    raw_info = struct.pack("BBB", batch_size, batch_index, batch_id)
+    raw_info = struct.pack("BBBB", product_id, batch_size, batch_index, batch_id)
 
     return safe32_encode(raw_info)
 
-def item_deserializer(serial: bytes | str) -> tuple[int, int, int]:
+def item_deserializer(serial: bytes | str) -> tuple[int, int, int, int]:
     """get information for item from serial
 
     Args:
@@ -40,18 +44,19 @@ def item_deserializer(serial: bytes | str) -> tuple[int, int, int]:
         Exception: unable to decode serial
 
     Returns:
-        tuple[int, int, int]: tuple of (batch_size, batch_index, batch_id)
+        tuple[int, int, int, int]: tuple of (product_id, batch_size, batch_index, batch_id)
     """
     
     raw_info = safe32_decode(serial)
-    batch_size, batch_index, batch_id = struct.unpack("BBB", raw_info)
+    product_id, batch_size, batch_index, batch_id = struct.unpack("BBBB", raw_info)
 
-    return (batch_size, batch_index, batch_id)
+    return (product_id, batch_size, batch_index, batch_id)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--serial", "-s", type=str, help="serial string to decode")
 
+    parser.add_argument("--product-id", "-p", type=int, help="product id to encode")
     parser.add_argument("--batch-size", "-z", type=int, help="batch size to encode")
     parser.add_argument("--batch-index", "-n", type=int, help="batch index to encode")
     parser.add_argument("--batch-id", "-i", type=int, help="batch id to encode")
@@ -60,19 +65,21 @@ if __name__ == "__main__":
 
     serial: str | None = args.serial
 
+    product_id: int | None = args.product_id
     batch_size: int | None = args.batch_size
     batch_index: int | None = args.batch_index
     batch_id: int | None = args.batch_id
 
     if serial is not None:
-            batch_size, batch_index, batch_id = item_deserializer(serial)
+            product_id, batch_size, batch_index, batch_id = item_deserializer(serial)
             print("item info:")
+            print(f"  {'product id:':<15}{product_id:>4}")
             print(f"  {'batch size:':<15}{batch_size:>4}")
             print(f"  {'batch index:':<15}{batch_index:>4}")
             print(f"  {'batch id:':<15}{batch_id:>4}")
-    elif batch_id is not None and batch_id is not None:
+    elif product_id is not None and batch_size is not None and batch_id is not None:
             if batch_index is not None:
-                print(f"item serial:  {item_serializer(batch_size, batch_index, batch_id).decode()}")
+                print(f"item serial:  {item_serializer(product_id, batch_size, batch_index, batch_id).decode()}")
             else:
                 for i in range(1, batch_size + 1):
-                    print(f"item {i:<3} serial:  {item_serializer(batch_size, i, batch_id).decode()}")
+                    print(f"item {i:<3} serial:  {item_serializer(product_id, batch_size, i, batch_id).decode()}")

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def item_deserializer(serial: str) -> tuple[int, int, int, int]:
     """get information for item from serial
 
     Args:
-        serial (bytes | str): item serial string
+        serial (str): item serial string
 
     Raises:
         Exception: unable to decode serial

--- a/main.py
+++ b/main.py
@@ -21,8 +21,8 @@ def item_serializer(product_id: int, batch_size: int, batch_index: int, batch_id
     Returns:
         bytes: serial as bytes
     """
-    if product_id > 255:
-        raise Exception("product id too large, must be less than or equal 255")
+    if product_id > 63:
+        raise Exception("product id too large, must be less than or equal 63")
     elif batch_size > 255:
         raise Exception("batch size too large, must be less than or equal 255")
     elif batch_id > 255:
@@ -34,7 +34,7 @@ def item_serializer(product_id: int, batch_size: int, batch_index: int, batch_id
 
     return safe32_encode(raw_info)
 
-def item_deserializer(serial: bytes | str) -> tuple[int, int, int, int]:
+def item_deserializer(serial: str) -> tuple[int, int, int, int]:
     """get information for item from serial
 
     Args:
@@ -42,10 +42,15 @@ def item_deserializer(serial: bytes | str) -> tuple[int, int, int, int]:
 
     Raises:
         Exception: unable to decode serial
+        Exception: bad serial length
 
     Returns:
         tuple[int, int, int, int]: tuple of (product_id, batch_size, batch_index, batch_id)
     """
+    if len(serial) != 6:
+        raise Exception("serial of wrong length, must be 6 characters")
+    else:
+        serial = b'0' + bytes(serial, 'utf-8')
     
     raw_info = safe32_decode(serial)
     product_id, batch_size, batch_index, batch_id = struct.unpack("BBBB", raw_info)
@@ -79,7 +84,7 @@ if __name__ == "__main__":
             print(f"  {'batch id:':<15}{batch_id:>4}")
     elif product_id is not None and batch_size is not None and batch_id is not None:
             if batch_index is not None:
-                print(f"item serial:  {item_serializer(product_id, batch_size, batch_index, batch_id).decode()}")
+                print(f"item serial:  {item_serializer(product_id, batch_size, batch_index, batch_id).decode()[1:]}")
             else:
                 for i in range(1, batch_size + 1):
-                    print(f"item {i:<3} serial:  {item_serializer(product_id, batch_size, i, batch_id).decode()}")
+                    print(f"item {i:<3} serial:  {item_serializer(product_id, batch_size, i, batch_id).decode()[1:]}")


### PR DESCRIPTION
added product id feature to track multiple product types. this resulted in a 7 digit serial, which is unacceptable, so i added a hack that limits the system to 64 possible product ids and throws out the leading 0 in the serial since it is not allowed to be any other value. 